### PR TITLE
Use local action in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: "Run JavaScript Action"
 on:
+  pull_request:
   push:
-    branches:    
+    branches:
+      - master
       - 'releases/*'   # only run in release distribution branches
 
 jobs:
@@ -12,6 +14,6 @@ jobs:
 
     - run: npm ci
     - run: npm test
-    - uses: actions/javascript-action@releases/v1
-      with: 
+    - uses: ./
+      with:
         milliseconds: 1000


### PR DESCRIPTION
Instead of this action pointing back to the template repo, it should probably use the local version in it's own test workflow.

I also added push to master for this, I am pretty sure it is what most people will expect.  I can break that out into a separate PR if you all think it is necessary.

EDIT: looks like my editor also removed trailing whitespace 🤷‍♂ 