### PR TITLE
Package action and do not checkin node_modules in any branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See the [toolkit documentation](https://github.com/actions/toolkit/blob/master/R
 
 ## Package for distribution
 
-Actions are run from GitHub repos.  Packaging the action will create a self encapsulated distribution runnable from the GitHub graph.
+Actions are run from GitHub repos.  Packaging the action will create a packaged action in the dist folder.
 
 Comment out node_modules in .gitignore and create a releases/v1 branch
 ```bash

--- a/README.md
+++ b/README.md
@@ -64,25 +64,31 @@ run()
 
 See the [toolkit documentation](https://github.com/actions/toolkit/blob/master/README.md#packages) for the various packages.
 
-## Publish to a distribution branch
+## Package for distribution
 
-Actions are run from GitHub repos.  We will create a releases branch and only checkin production modules (core in this case). 
+Actions are run from GitHub repos.  Packaging the action will create a self encapsulated distribution runnable from the GitHub graph.
 
 Comment out node_modules in .gitignore and create a releases/v1 branch
 ```bash
-# comment this out distribution branches
-# node_modules/
+npm run package
+```
+
+Since the packaged index.js is run from the dist folder, check it in.
+
+```bash
+git add dist
+```
+
+## Create a release branch
+
+Users shouldn't consume the action from master since that would be latest code and actions can break compatibility between major versions.
+
+```bash
+$ git checkout -b v1
+$ git commit -a -m "v1 release"
 ```
 
 ```bash
-$ git checkout -b releases/v1
-$ git commit -a -m "prod dependencies"
-```
-
-```bash
-$ npm prune --production
-$ git add node_modules
-$ git commit -a -m "prod dependencies"
 $ git push origin releases/v1
 ```
 
@@ -90,24 +96,14 @@ Your action is now published! :rocket:
 
 See the [versioning documentation](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md)
 
-## Validate
+## Usage
 
-You can now validate the action by referencing the releases/v1 branch
-
-```yaml
-uses: actions/javascript-action@releases/v1
-with:
-  milliseconds: 1000
-```
-
-See the [actions tab](https://github.com/actions/javascript-action/actions) for runs of this action! :rocket:
-
-## Usage:
-
-After testing you can [create a v1 tag](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md) to reference the stable and tested action
+You can now consume the action by referencing the v1 branch
 
 ```yaml
 uses: actions/javascript-action@v1
 with:
   milliseconds: 1000
 ```
+
+See the [actions tab](https://github.com/actions/javascript-action/actions) for runs of this action! :rocket:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ See the [toolkit documentation](https://github.com/actions/toolkit/blob/master/R
 
 Actions are run from GitHub repos.  Packaging the action will create a packaged action in the dist folder.
 
-Comment out node_modules in .gitignore and create a releases/v1 branch
+Run package
+
 ```bash
 npm run package
 ```

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ outputs:
     description: 'The message to output'
 runs:
   using: 'node12'
-  main: 'index.js'
+  main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,364 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(104);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 87:
+/***/ (function(module) {
+
+module.exports = require("os");
+
+/***/ }),
+
+/***/ 104:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const core = __webpack_require__(470);
+const wait = __webpack_require__(949);
+
+
+// most @actions toolkit packages have async methods
+async function run() {
+  try { 
+    const ms = core.getInput('milliseconds');
+    console.log(`Waiting ${ms} milliseconds ...`)
+
+    core.debug((new Date()).toTimeString())
+    wait(parseInt(ms));
+    core.debug((new Date()).toTimeString())
+
+    core.setOutput('time', new Date().toTimeString());
+  } 
+  catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+run()
+
+
+/***/ }),
+
+/***/ 431:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+const os = __webpack_require__(87);
+/**
+ * Commands
+ *
+ * Command Format:
+ *   ##[name key=value;key=value]message
+ *
+ * Examples:
+ *   ##[warning]This is the user warning message
+ *   ##[set-secret name=mypassword]definitelyNotAPassword!
+ */
+function issueCommand(command, properties, message) {
+    const cmd = new Command(command, properties, message);
+    process.stdout.write(cmd.toString() + os.EOL);
+}
+exports.issueCommand = issueCommand;
+function issue(name, message = '') {
+    issueCommand(name, {}, message);
+}
+exports.issue = issue;
+const CMD_STRING = '::';
+class Command {
+    constructor(command, properties, message) {
+        if (!command) {
+            command = 'missing.command';
+        }
+        this.command = command;
+        this.properties = properties;
+        this.message = message;
+    }
+    toString() {
+        let cmdStr = CMD_STRING + this.command;
+        if (this.properties && Object.keys(this.properties).length > 0) {
+            cmdStr += ' ';
+            for (const key in this.properties) {
+                if (this.properties.hasOwnProperty(key)) {
+                    const val = this.properties[key];
+                    if (val) {
+                        // safely append the val - avoid blowing up when attempting to
+                        // call .replace() if message is not a string for some reason
+                        cmdStr += `${key}=${escape(`${val || ''}`)},`;
+                    }
+                }
+            }
+        }
+        cmdStr += CMD_STRING;
+        // safely append the message - avoid blowing up when attempting to
+        // call .replace() if message is not a string for some reason
+        const message = `${this.message || ''}`;
+        cmdStr += escapeData(message);
+        return cmdStr;
+    }
+}
+function escapeData(s) {
+    return s.replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+function escape(s) {
+    return s
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A')
+        .replace(/]/g, '%5D')
+        .replace(/;/g, '%3B');
+}
+//# sourceMappingURL=command.js.map
+
+/***/ }),
+
+/***/ 470:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const command_1 = __webpack_require__(431);
+const os = __webpack_require__(87);
+const path = __webpack_require__(622);
+/**
+ * The code to exit an action
+ */
+var ExitCode;
+(function (ExitCode) {
+    /**
+     * A code indicating that the action was successful
+     */
+    ExitCode[ExitCode["Success"] = 0] = "Success";
+    /**
+     * A code indicating that the action was a failure
+     */
+    ExitCode[ExitCode["Failure"] = 1] = "Failure";
+})(ExitCode = exports.ExitCode || (exports.ExitCode = {}));
+//-----------------------------------------------------------------------
+// Variables
+//-----------------------------------------------------------------------
+/**
+ * sets env variable for this action and future actions in the job
+ * @param name the name of the variable to set
+ * @param val the value of the variable
+ */
+function exportVariable(name, val) {
+    process.env[name] = val;
+    command_1.issueCommand('set-env', { name }, val);
+}
+exports.exportVariable = exportVariable;
+/**
+ * exports the variable and registers a secret which will get masked from logs
+ * @param name the name of the variable to set
+ * @param val value of the secret
+ */
+function exportSecret(name, val) {
+    exportVariable(name, val);
+    // the runner will error with not implemented
+    // leaving the function but raising the error earlier
+    command_1.issueCommand('set-secret', {}, val);
+    throw new Error('Not implemented.');
+}
+exports.exportSecret = exportSecret;
+/**
+ * Prepends inputPath to the PATH (for this action and future actions)
+ * @param inputPath
+ */
+function addPath(inputPath) {
+    command_1.issueCommand('add-path', {}, inputPath);
+    process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
+}
+exports.addPath = addPath;
+/**
+ * Gets the value of an input.  The value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string
+ */
+function getInput(name, options) {
+    const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
+    if (options && options.required && !val) {
+        throw new Error(`Input required and not supplied: ${name}`);
+    }
+    return val.trim();
+}
+exports.getInput = getInput;
+/**
+ * Sets the value of an output.
+ *
+ * @param     name     name of the output to set
+ * @param     value    value to store
+ */
+function setOutput(name, value) {
+    command_1.issueCommand('set-output', { name }, value);
+}
+exports.setOutput = setOutput;
+//-----------------------------------------------------------------------
+// Results
+//-----------------------------------------------------------------------
+/**
+ * Sets the action status to failed.
+ * When the action exits it will be with an exit code of 1
+ * @param message add error issue message
+ */
+function setFailed(message) {
+    process.exitCode = ExitCode.Failure;
+    error(message);
+}
+exports.setFailed = setFailed;
+//-----------------------------------------------------------------------
+// Logging Commands
+//-----------------------------------------------------------------------
+/**
+ * Writes debug message to user log
+ * @param message debug message
+ */
+function debug(message) {
+    command_1.issueCommand('debug', {}, message);
+}
+exports.debug = debug;
+/**
+ * Adds an error issue
+ * @param message error issue message
+ */
+function error(message) {
+    command_1.issue('error', message);
+}
+exports.error = error;
+/**
+ * Adds an warning issue
+ * @param message warning issue message
+ */
+function warning(message) {
+    command_1.issue('warning', message);
+}
+exports.warning = warning;
+/**
+ * Writes info to log with console.log.
+ * @param message info message
+ */
+function info(message) {
+    process.stdout.write(message + os.EOL);
+}
+exports.info = info;
+/**
+ * Begin an output group.
+ *
+ * Output until the next `groupEnd` will be foldable in this group
+ *
+ * @param name The name of the output group
+ */
+function startGroup(name) {
+    command_1.issue('group', name);
+}
+exports.startGroup = startGroup;
+/**
+ * End an output group.
+ */
+function endGroup() {
+    command_1.issue('endgroup');
+}
+exports.endGroup = endGroup;
+/**
+ * Wrap an asynchronous function call in a group.
+ *
+ * Returns the same type as the function itself.
+ *
+ * @param name The name of the group
+ * @param fn The function to wrap in the group
+ */
+function group(name, fn) {
+    return __awaiter(this, void 0, void 0, function* () {
+        startGroup(name);
+        let result;
+        try {
+            result = yield fn();
+        }
+        finally {
+            endGroup();
+        }
+        return result;
+    });
+}
+exports.group = group;
+//# sourceMappingURL=core.js.map
+
+/***/ }),
+
+/***/ 622:
+/***/ (function(module) {
+
+module.exports = require("path");
+
+/***/ }),
+
+/***/ 949:
+/***/ (function(module) {
+
+let wait = function(milliseconds) {
+  return new Promise((resolve, reject) => {
+    if (typeof(milliseconds) !== 'number') { 
+      throw new Error('milleseconds not a number'); 
+    }
+
+    setTimeout(() => resolve("done!"), milliseconds)
+  });
+}
+
+module.exports = wait;
+
+
+/***/ })
+
+/******/ });

--- a/package-lock.json
+++ b/package-lock.json
@@ -477,6 +477,12 @@
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
     },
+    "@zeit/ncc": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.20.5.tgz",
+      "integrity": "sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw==",
+      "dev": true
+    },
     "abab": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
@@ -1008,9 +1014,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "optional": true
     },
@@ -1202,6 +1208,31 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
       "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
       "dev": true
+    },
+    "dist": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dist/-/dist-0.1.2.tgz",
+      "integrity": "sha1-iJhinMJRKX420TVKmpWYYZq6Wxo=",
+      "requires": {
+        "filesize": "~1.6.6",
+        "optimist": "~0.3.5",
+        "uglify-js": "~1.3.4"
+      },
+      "dependencies": {
+        "optimist": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+          "requires": {
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "uglify-js": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
+          "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0="
+        }
+      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -1680,6 +1711,11 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "filesize": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-1.6.7.tgz",
+      "integrity": "sha1-DQrPJoUeKnM5/8RayH48Lt/w6W4="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -2411,9 +2447,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5057,13 +5093,13 @@
       }
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
+      "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       }
     },
@@ -5251,8 +5287,7 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1209,31 +1209,6 @@
       "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
       "dev": true
     },
-    "dist": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dist/-/dist-0.1.2.tgz",
-      "integrity": "sha1-iJhinMJRKX420TVKmpWYYZq6Wxo=",
-      "requires": {
-        "filesize": "~1.6.6",
-        "optimist": "~0.3.5",
-        "uglify-js": "~1.3.4"
-      },
-      "dependencies": {
-        "optimist": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "requires": {
-            "wordwrap": "~0.0.2"
-          }
-        },
-        "uglify-js": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-          "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0="
-        }
-      }
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1711,11 +1686,6 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
-    },
-    "filesize": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-1.6.7.tgz",
-      "integrity": "sha1-DQrPJoUeKnM5/8RayH48Lt/w6W4="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -5287,7 +5257,8 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   },
   "homepage": "https://github.com/actions/javascript-action#readme",
   "dependencies": {
-    "@actions/core": "^1.1.1",
-    "dist": "^0.1.2"
+    "@actions/core": "^1.1.1"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.20.5",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint index.js",
+    "package": "ncc build index.js -o dist",
     "test": "eslint index.js && jest"
   },
   "repository": {
@@ -23,9 +24,11 @@
   },
   "homepage": "https://github.com/actions/javascript-action#readme",
   "dependencies": {
-    "@actions/core": "^1.1.1"
+    "@actions/core": "^1.1.1",
+    "dist": "^0.1.2"
   },
   "devDependencies": {
+    "@zeit/ncc": "^0.20.5",
     "eslint": "^6.3.0",
     "jest": "^24.9.0"
   }


### PR DESCRIPTION
Checking in node_modules causes many problems even if it's in a distribution branch.  There's no way to ignore just dev dependencies and it's painful to work in master and merge down but keep two different working models between the branches.

ncc has solve this and also works with typescript (even though this template is just js)