### PR TITLE
split into two jobs for better testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: "test-local"
+name: "units-test"
 on:
   pull_request:
   push:
@@ -7,13 +7,19 @@ on:
       - 'releases/*'
 
 jobs:
+  # unit tests
+  units:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: npm ci
+    - run: npm test
+
+  # test action works running from the graph  
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-
-    - run: npm ci
-    - run: npm test
     - uses: ./
       with:
         milliseconds: 1000


### PR DESCRIPTION
unit test job and running from the github graph as the runner would run it (without an npm install)