### PR TITLE
Use recommended hook script for building package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint index.js",
-    "package": "ncc build index.js -o dist",
+    "prepare": "ncc build index.js -o dist",
     "test": "eslint index.js && jest"
   },
   "repository": {


### PR DESCRIPTION
The `prepare` script is the recommended (and purpose-built) script for building/bundling/compiling. It runs on bare npm-install (so it's the necessary script for git-deps), and it's run automatically as part of pack and publish.

Since this repo is intended as a template to bootstrap other actions, I think it's especially important to use the correct (both semantically and conventionally) configuration.