### PR TITLE
Generate source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint index.js",
-    "package": "ncc build index.js -o dist",
+    "package": "ncc --source-maps build index.js -o dist",
     "test": "eslint index.js && jest"
   },
   "repository": {


### PR DESCRIPTION
Adds the `ncc` flag to generate source maps, improving debuggability.