### PR TITLE
fix: setting process.env to child_pocess

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -19,5 +19,5 @@ test('wait 500 ms', async() => {
 test('test runs', () => {
     process.env['INPUT_MILLISECONDS'] = 500;
     const ip = path.join(__dirname, 'index.js');
-    console.log(cp.execSync(`node ${ip}`).toString());
+    console.log(cp.execSync(`node ${ip}`, { env: process.env }).toString());
 })


### PR DESCRIPTION
set the process.env on `index.test.js` is not work in the child_pocess

to ensuer that process.env is same,  should be use the `child_pocess.execSync` second parameter

here is the [doc](
https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options)