### PR TITLE
fix: expected time difference post wait call

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -12,7 +12,7 @@ test('wait 500 ms', async () => {
   await wait(500);
   const end = new Date();
   var delta = Math.abs(end - start);
-  expect(delta).toBeGreaterThan(450);
+  expect(delta).toBeGreaterThan(500);
 });
 
 // shows how the runner will run a javascript action with env / stdout protocol


### PR DESCRIPTION
Hello all,

I have updated the unit test for the time difference between the `start` and `end` of `wait` method execution.

As far as I understand, at any given condition, the value can never go below 500ms if the `wait` method is called with the argument as `500`. Since it's a `setTimeout` at the back which will be triggered in its respective tick, and it won't get triggered before 500ms are elapsed.

Result:
![image](https://user-images.githubusercontent.com/22256912/89942604-81ac7b80-dc3a-11ea-8f81-294eac58324e.png)

Thanks,
Rohan Chougule