### PR TITLE
Replace the deprecated zeit package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -746,10 +746,10 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
-    "@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
+    "@vercel/ncc": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.23.0.tgz",
+      "integrity": "sha512-Fcr1qlG9t54X4X9qbo/+jr1+t5Qc6H3TgIRBXmKkF/WDs6YFulAN6ilq2Ehx38RbgIOFxaZnjlAQ50GyexnMpQ==",
       "dev": true
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@actions/core": "^1.1.1"
   },
   "devDependencies": {
-    "@zeit/ncc": "^0.22.3",
+    "@vercel/ncc": "^0.23.0",
     "eslint": "^7.4.0",
     "jest": "^26.1.0"
   }


### PR DESCRIPTION
This PR simply replaces the zeit package with the newly released vercel package.