### PR TITLE
Remove extra word from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm test
 
 ## Change action.yml
 
-The action.yml contains defines the inputs and output for your action.
+The action.yml defines the inputs and output for your action.
 
 Update the action.yml with your name, description, inputs and outputs for your action.
 


### PR DESCRIPTION
Hey everyone 👋 

Here's a tiny PR that removes the word `contains` from the README. The other option would be to refrase the sentence as `The action.yml contains and defines...`. 

Let me know your thoughts!

Thank you so much for your work 🙇 