### PR TITLE
Fix description of `time` output in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: '1000'
 outputs:
   time: # output will be available to future steps
-    description: 'The message to output'
+    description: 'The current time after waiting'
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
The old example probably is not what people should emulate when they write descriptions of their actions' outputs.