### PR TITLE
Fix extensions in test headers

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the action's entrypoint, src/index.ts
+ * Unit tests for the action's entrypoint, src/index.js
  */
 
 const { run } = require('../src/main')

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,9 +1,5 @@
 /**
- * Unit tests for the action's main functionality, src/main.ts
- *
- * These should be run as if the action was called from a workflow.
- * Specifically, the inputs listed in `action.yml` should be set as environment
- * variables following the pattern `INPUT_<INPUT_NAME>`.
+ * Unit tests for the action's main functionality, src/main.js
  */
 const core = require('@actions/core')
 const main = require('../src/main')

--- a/__tests__/wait.test.js
+++ b/__tests__/wait.test.js
@@ -4,7 +4,7 @@
 const { wait } = require('../src/wait')
 const { expect } = require('@jest/globals')
 
-describe('wait.ts', () => {
+describe('wait.js', () => {
   it('throws an invalid number', async () => {
     const input = parseInt('foo', 10)
     expect(isNaN(input)).toBe(true)

--- a/__tests__/wait.test.js
+++ b/__tests__/wait.test.js
@@ -1,5 +1,5 @@
 /**
- * Unit tests for src/wait.ts
+ * Unit tests for src/wait.js
  */
 const { wait } = require('../src/wait')
 const { expect } = require('@jest/globals')


### PR DESCRIPTION
This PR updates the file extensions in the tests to reference the correct files (JavaScript, not TypeScript).

Fixes #340 