### PR TITLE
Update LICENSE and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,10 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    labels:
-      - dependabot
-      - actions
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: npm
     directory: /
-    labels:
-      - dependabot
-      - npm
     schedule:
-      interval: daily
+      interval: weekly

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
+MIT License
 
-The MIT License (MIT)
-
-Copyright (c) 2019 GitHub Actions
+Copyright GitHub
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR does the following:

- Updates `LICENSE` to GitHub's standard MIT license
- Changes the Dependabot configuration to run weekly
- Removes the additional labels added by Dependabot (as they may not exist in developers' new repos)