### PR TITLE
docs: apply alert style correctly at warning message

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ So, what are you waiting for? Go ahead and start customizing your action!
    npm run all
    ```
 
-   > [!WARNING]
-   >
-   > This step is important! It will run [`ncc`](https://github.com/vercel/ncc)
-   > to build the final JavaScript action code with all dependencies included.
-   > If you do not run this step, your action will not work correctly when it is
-   > used in a workflow. This step also includes the `--license` option for
-   > `ncc`, which will create a license file for all of the production node
-   > modules used in your project.
+> [!WARNING]
+>
+> This step is important! It will run [`ncc`](https://github.com/vercel/ncc)
+> to build the final JavaScript action code with all dependencies included.
+> If you do not run this step, your action will not work correctly when it is
+> used in a workflow. This step also includes the `--license` option for
+> `ncc`, which will create a license file for all of the production node
+> modules used in your project.
 
 1. Commit your changes
 


### PR DESCRIPTION
# Summary
Remove space for GitHub alert syntax

## Before
![スクリーンショット 2024-10-07 163633](https://github.com/user-attachments/assets/93d7a33f-714c-45b1-98c8-c24b21585902)

## After
![スクリーンショット 2024-10-07 163656](https://github.com/user-attachments/assets/b8bd2085-1a2c-44d5-a491-b8d92384549a)

x-ref: [Basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)