### PR TITLE
Add basic release management

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -9,15 +9,33 @@
 # expected from the build.
 name: Check Transpiled JavaScript
 
+# This workflow will only run on PRs targeting `main` and direct pushes to
+# `main`. It will only run if the listed files/paths are modified (e.g. there is
+# no need to run this workflow when documentation files are modified).
 on:
   pull_request:
     branches:
       - main
+    paths:
+      - src/**
+      - .node-version
+      - .prettierrc.json
+      - package.json
+      - package-lock.json
+      - tsconfig.json
   push:
     branches:
       - main
+    paths:
+      - src/**
+      - .node-version
+      - .prettierrc.json
+      - package.json
+      - package-lock.json
+      - tsconfig.json
 
 permissions:
+  checks: write
   contents: read
 
 jobs:
@@ -47,7 +65,7 @@ jobs:
 
       # This will fail the workflow if the `dist/` directory is different than
       # expected.
-      - name: Compare Directories
+      - name: Compare Expected and Actual Directories
         id: diff
         run: |
           if [ ! -d dist/ ]; then

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1,0 +1,60 @@
+# This workflow creates a new release any time a PR is merged that includes an
+# update to the version listed in `package.json`. This ensures that the releases
+# are always in sync with the version listed in the package manifest.
+name: Continuous Delivery
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release Version
+    runs-on: ubuntu-latest
+
+    # Only run this job if the workflow was triggered manually or a
+    # non-Dependabot PR was merged.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+      startsWith(github.head_ref, 'dependabot/') == false)
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Parse the version from package.json and, if not already present,
+      # publish a new action version.
+      - name: Tag
+        id: tag
+        uses: issue-ops/semver@v2
+        with:
+          manifest-path: package.json
+          workspace: ${{ github.workspace }}
+          ref: main
+
+          # Always overwrite if the workflow was triggered manually.
+          overwrite: ${{ github.event_name == 'workflow_dispatch' }}
+
+      # Create a release using the tag from the previous step. The release will
+      # always be created if the workflow was triggered manually, but will only
+      # be created on PR merge if the tag step ran successfully.
+      - if: |
+          github.event_name == 'workflow_dispatch' ||
+          steps.tag.outcome == 'success'
+        name: Create Release
+        id: release
+        uses: issue-ops/releaser@v2
+        with:
+          tag: v${{ steps.tag.outputs.version }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,3 +1,5 @@
+# This workflow performs CI tests to ensure that the code reaching `main`
+# has been tested and validated.
 name: Continuous Integration
 
 on:
@@ -9,6 +11,7 @@ on:
       - main
 
 permissions:
+  checks: write
   contents: read
 
 jobs:
@@ -57,7 +60,7 @@ jobs:
         id: test-action
         uses: ./
         with:
-          milliseconds: 1000
+          milliseconds: 2000
 
       - name: Print Output
         id: output

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,41 @@
+# This workflow checks the version of the action that will be published by the
+# current pull request. If the version has already been published, the workflow
+# fails in order to prevent PRs from being merged until the version has been
+# incremented in the package.json manifest file.
+name: Version Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  MANIFEST_PATH: package.json
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-version:
+    name: Version Check
+    runs-on: ubuntu-latest
+
+    # Skips Dependabot PRs
+    if: ${{ startsWith(github.head_ref, 'dependabot/') == false }}
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check Version
+        id: check-version
+        uses: issue-ops/semver@v2
+        with:
+          check-only: true
+          manifest-path: ${{ env.MANIFEST_PATH }}

--- a/README.md
+++ b/README.md
@@ -229,3 +229,28 @@ steps:
     id: output
     run: echo "${{ steps.run-action.outputs.time }}"
 ```
+
+## Publishing a New Release
+
+This project includes two workflow files, `continuous-integration.yml` and
+`continuous-delivery.yml` that are used to build, test, and publish new releases
+of the action.
+
+The `continuous-integration.yml` workflow is triggered on every push to a pull
+request branch. It will run unit tests and add a comment to the pull request
+with the test results.
+
+The `continuous-delivery.yml` workflow is triggered when a pull request is
+merged to the `main` branch. It will create a new release of the action based on
+the version specified in the `version` property of the `package.json` file.
+
+The steps to publish a new version are as follows:
+
+1. Create a feature branch
+1. Make changes to the action code
+1. Add tests for the changes
+1. Update the `version` property in the `package.json` file
+1. Commit and push the changes to the feature branch
+1. Open a pull request to merge the changes to the `main` branch
+
+After the pull request is merged, a new release will be created automatically.


### PR DESCRIPTION
This PR adds basic release management via updated CI/CD workflow files.

- **`check-dist.yml`:**
  - Adds basic informational comments
  - Skips running the action when only meta files are modified
- **`continuous-delivery.yml`:**
  - Automatically creates GitHub Releases when PRs are merged that contain updates to the action version in `package.json`
- **`ci.yml` -> `continuous-integration.yml`:**
  - Adds basic informational comments
- **`version-check.yml`:**
  - Checks if the version specified in `package.json` has been published as a release and, if so, fails the PR check
  - Comments on the PR with the current version check status (single comment, modified each time the workflow runs)
